### PR TITLE
feat: add Markdown language to linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Since this repo is primarily Markdown, count it as a significant language.
+*.md linguist-detectable


### PR DESCRIPTION
Since this repo is not empty and its primary language is Markdown, this allows Github's linguist to count it as a language