### PR TITLE
fix: try to make Markdown detected by linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
 # Since this repo is primarily Markdown, count it as a significant language.
-*.md linguist-detectable
+*.md linguist-vendored=false
+*.md linguist-generated=false
+*.md linguist-documentation=false
+*.md linguist-detectable=true


### PR DESCRIPTION
Seems like '*.md linguist-detectable' only is not enough